### PR TITLE
Updated dependency to Elixir 1.0.0-rc2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Linguist.Mixfile do
   def project do
     [
       app: :linguist,
-      version: "0.1.1",
-      elixir: "~> 0.15.0",
+      version: "0.2.0",
+      elixir: "~> 1.0.0-rc2",
       deps: deps,
       package: [
         contributors: ["Chris McCord"],


### PR DESCRIPTION
Trying to build phoenix against elixir 1.0.0-rc2.

I have not been following the breaking changes between 0.15.1 and 1.0.0-rc2, but I also incremented the minor number just in case.
