### PR TITLE
Simple Implementation to escape %{name} by %%{name}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps
 erl_crash.dump
 *.ez
+.tmux.rb

--- a/test/en.exs
+++ b/test/en.exs
@@ -12,7 +12,8 @@
     profiles: [
       title: "Profiles",
     ]
-  ]
+  ],
+  escaped: "%%{escaped}"
 ]
 
 

--- a/test/escaping_test.exs
+++ b/test/escaping_test.exs
@@ -1,0 +1,37 @@
+defmodule EscapingTest do
+  use ExUnit.Case
+
+  defmodule Esc do
+    use Linguist.Vocabulary
+
+    locale "en", []
+
+    locale "fr", [
+      level:
+      [
+        basic: "%%{escaped}",
+        mixed: "%{a} %%{a} %{a} %%{a}"
+      ]
+    ]
+  end
+
+  test "t does not escape %%{ but replaces %% by %" do
+    assert Esc.t!("fr", "level.basic" ) == "%{escaped}"
+  end
+
+  test "even if key is in the binding" do
+    assert Esc.t!("fr", "level.basic", escaped: "Does not matter" ) == "%{escaped}"
+  end
+
+  test "mixed form" do
+    assert Esc.t!("fr", "level.mixed", a: 42 ) == "42 %{a} 42 %{a}"
+  end
+
+  test "mixed form, no values" do
+    assert_raise KeyError, fn ->
+      Esc.t! "fr", "level.mixed"
+    end
+  end
+end
+
+

--- a/test/vocabulary_test.exs
+++ b/test/vocabulary_test.exs
@@ -12,7 +12,7 @@ defmodule LinguistTest do
           hello: "salut %{first} %{last}"
         ],
         interpolation_at_beginning: "%{name} at beginning",
-     ]
+      ]
     ]
   end
 
@@ -37,7 +37,7 @@ defmodule LinguistTest do
     assert I18n.t("en", "users.profiles.title") == {:ok, "Profiles"}
   end
 
-  test "it iterpolates bindings" do
+  test "it interpolates bindings" do
     assert I18n.t!("en", "flash.notice.hello", first: "chris", last: "mccord") == "hello chris mccord"
     assert I18n.t("en", "flash.notice.hello", first: "chris", last: "mccord") == {:ok, "hello chris mccord"}
     assert I18n.t!("en", "flash.notice.bye", name: "chris") == "bye now, chris!"


### PR DESCRIPTION
This is for issue #17

Excerpt from added tests

``` elixir
  defmodule Esc do                                                                                                                                                              
    use Linguist.Vocabulary                                                                                                                                                     

    locale "en", []                                                                                                                                                             

    locale "fr", [                                                                                                                                                              
      level:                                                                                                                                                                    
      [                                                                                                                                                                         
        basic: "%%{escaped}",                                                                                                                                                   
        mixed: "%{a} %%{a} %{a} %%{a}"                                                                                                                                          
      ]                                                                                                                                                                         
    ]                                                                                                                                                                           
  end                                                                                                                                                                           

  test "t does not escape %%{ but replaces %% by %" do                                                                                                                          
    assert Esc.t!("fr", "level.basic" ) == "%{escaped}"                                                                                                                         
  end             
```
