### PR TITLE
basic plurals (zero, one, two, other)

### DIFF
--- a/lib/linguist/compiler.ex
+++ b/lib/linguist/compiler.ex
@@ -37,12 +37,6 @@ defmodule Linguist.Compiler do
   @escaped_interpol_rgx ~r/%%{/
   @simple_interpol "%{"
 
-  @plural_keys ["one", "other"]
-  @plural_functions [
-    "one": fn (counter) -> counter == 1 end,
-    "other": fn (counter) -> counter != 1 end
-  ]
-
   def compile(translations) do
     langs = Dict.keys translations
     translations =

--- a/test/ja.exs
+++ b/test/ja.exs
@@ -14,9 +14,7 @@
     ],
     friends: [
       _plural: true,
-      zero: "no friends",
-      one: "1 friend",
-      other: "%{count} friends"
+      other: "%{count}人友達"
     ]
   ],
   escaped: "%%{escaped}"

--- a/test/plural_test.exs
+++ b/test/plural_test.exs
@@ -1,0 +1,22 @@
+defmodule PluralTest do
+  use ExUnit.Case
+
+  defmodule I18n do
+    use Linguist.Vocabulary
+
+    locale "en", Path.join([__DIR__, "en.exs"])
+    locale "ja", Path.join([__DIR__, "ja.exs"])
+  end
+
+  test "it handles English plurals" do
+    assert I18n.t!("en", "users.friends", count: 0) == "no friends"
+    assert I18n.t!("en", "users.friends", count: 1) == "1 friend"
+    assert I18n.t!("en", "users.friends", count: 2) == "2 friends"
+  end
+
+  test "it handles Japanese plurals" do
+    assert I18n.t!("ja", "users.friends", count: 0) == "0人友達"
+    assert I18n.t!("ja", "users.friends", count: 1) == "1人友達"
+    assert I18n.t!("ja", "users.friends", count: 2) == "2人友達"
+  end
+end


### PR DESCRIPTION
What it does:

Change messages to fit the right counter passed in by "count", when a { _plural: true } key is included in the translations file.

English and Japanese examples:

``` javascript
friends: [
   _plural: true,
   zero: "no friends",
   one: "1 friend",
   other: "%{count} friends"
 ]

friends: [
  _plural: true,
  other: "%{count}人友達"
]
```

Strengths: makes your English plurals easier, most European languages, Chinese/Japanese/Korean and many more. Any language whose special rules can be limited to "zero", "one", "two", or "other"

Weaknesses: doesn't work with Arabic or Russian (which have special "few" and "many" plurals), and other languages with their own definitions of "few" and "many". Cannot add new plural rule lambdas with current setup =(

closes #9
