### PR TITLE
Fix warning on Elixir 1.3 

### DIFF
--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -66,9 +66,11 @@ defmodule Linguist.Vocabulary do
   """
   defmacro locale(name, source) do
     quote bind_quoted: [name: name, source: source] do
-      if is_binary(source) do
+      source = if is_binary(source) do
         @external_resource source
-        source = Code.eval_file(source) |> elem(0)
+        Code.eval_file(source) |> elem(0)
+      else
+        source
       end
       @locales {name, source}
     end


### PR DESCRIPTION
This should fix the following warning:

```
warning: the variable "source" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  web/i18n.ex:4
```
