### PR TITLE
Add YAML file parsing for loading translations

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,13 +21,14 @@ defmodule Linguist.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:yaml_elixir]]
   end
 
   defp deps do
     [
       {:ex_cldr, "~> 1.5"},
-      {:jason, "~> 1.0"}
+      {:jason, "~> 1.0"},
+      {:yaml_elixir, "~> 2.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,6 @@
   "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "ex_cldr": {:hex, :ex_cldr, "1.5.2", "5c8fe295fef680a821b9e0c19242ea34037af11eb59e6d98f194e6c9c3b4252e", [:mix], [{:abnf2, "~> 0.1", [hex: :abnf2, repo: "hexpm", optional: false]}, {:decimal, "~> 1.4", [hex: :decimal, repo: "hexpm", optional: false]}, {:gettext, "~> 0.13", [hex: :gettext, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix, "~> 1.3", [hex: :phoenix, repo: "hexpm", optional: true]}, {:plug, "~> 1.4", [hex: :plug, repo: "hexpm", optional: true]}, {:poison, "~> 2.1 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], [], "hexpm"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.0.0", "5d7c40e039b076c0da1921b2754d4a91bc435ac4434bef633f5506dbafd6b8f2", [:mix], [{:yamerl, "~> 0.5", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/es.yml
+++ b/test/es.yml
@@ -1,0 +1,15 @@
+---
+foo: "bar"
+flash:
+  notice:
+    alert: "Alerta!"
+    hello: "hola %{first} %{last}"
+    bye: "adios, %{name}!"
+users:
+  title: "Usuarios"
+  profiles:
+    title: "Perfiles"
+escaped: "%%{escaped}"
+apple:
+  one: "%{count} manzana"
+  other: "%{count} manzanas"

--- a/test/vocabulary_test.exs
+++ b/test/vocabulary_test.exs
@@ -3,6 +3,7 @@ defmodule LinguistTest do
 
   defmodule I18n do
     use Linguist.Vocabulary
+    locale("es", Path.join([__DIR__, "es.yml"]))
 
     locale("en", Path.join([__DIR__, "en.exs"]))
 
@@ -22,7 +23,7 @@ defmodule LinguistTest do
   end
 
   test "it returns locales" do
-    assert ["fr", "en"] == I18n.locales()
+    assert ["fr", "en", "es"] == I18n.locales()
   end
 
   test "it handles translations at rool level" do
@@ -103,5 +104,9 @@ defmodule LinguistTest do
         I18n.t!("en", "apple")
       end
     end
+  end
+
+  test "translations in yaml files are loaded successfully" do
+    assert I18n.t!("es", "flash.notice.hello", first: 123, last: "mccord") == "hola 123 mccord"
   end
 end


### PR DESCRIPTION
@mertonium 

When files are loaded from yaml, they come in the format of:
```elixir
%{ "key" => "value" }
```
Some transforms are required to get them into
```elixir
[key: "value"]
```
These transforms are done inside the library.