### PR TITLE
Swap out yomel for yaml_elixir

### DIFF
--- a/lib/linguist/memorized_vocabulary.ex
+++ b/lib/linguist/memorized_vocabulary.ex
@@ -123,7 +123,7 @@ defmodule Linguist.MemorizedVocabulary do
       :ets.new(:translations_registry, [:named_table, :set, :protected])
     end
 
-    {decode_status, [file_data]} = Yomel.decode_file(source)
+    {decode_status, [file_data]} = YamlElixir.read_all_from_file(source)
     if decode_status != :ok do
       raise %TranslationDecodeError{message: "Decode failed for file #{source}"}
     end
@@ -144,7 +144,7 @@ defmodule Linguist.MemorizedVocabulary do
       "#{acc.current_prefix}.#{key}"
     end
 
-    %{ 
+    %{
       paths: Map.put(acc.paths, key_name, value),
       current_prefix: acc.current_prefix
     }

--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -87,7 +87,7 @@ defmodule Linguist.Vocabulary do
   will not work as expected if called directly.
   """
   def _load_yaml_file(source) do
-    {:ok, [result]} = Yomel.decode_file(source)
+    {:ok, [result]} = YamlElixir.read_all_from_file(source)
     result
     |> Enum.reduce([], &Linguist.Vocabulary._yaml_reducer/2)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,14 +22,14 @@ defmodule Linguist.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:yaml_elixir]]
   end
 
   defp deps do
     [
       {:ex_cldr, "~> 1.5"},
       {:jason, "~> 1.0"},
-      {:yomel, "~> 0.5"},
+      {:yaml_elixir, "~> 2.0"},
       {:credo, "~> 0.9.0", only: [:dev, :test], runtime: false}
     ]
   end


### PR DESCRIPTION
Yomel depends on libyaml which isn't always available. YamlElixir, on the
other hand, wraps around the native Erlang yaml parser (yamerl).

This commit will reduce our external dependencies and make CI/release building
run a bit smoother.

@willbarrett @robdiciuccio 