### PR TITLE
add normalize locale function to linguist

### DIFF
--- a/lib/linguist/memorized_vocabulary.ex
+++ b/lib/linguist/memorized_vocabulary.ex
@@ -37,16 +37,27 @@ defmodule Linguist.MemorizedVocabulary do
 
   def t(locale, path, bindings \\ []) do
     pluralization_key = Application.fetch_env!(:linguist, :pluralization_key)
+    norm_locale = normalize_locale(locale)
+
     if Keyword.has_key?(bindings, pluralization_key) do
       plural_atom =
         Cardinal.plural_rule(
           Keyword.get(bindings, pluralization_key),
-          locale
+          norm_locale
         )
 
-      do_t(locale, "#{path}.#{plural_atom}", bindings)
+      do_t(norm_locale, "#{path}.#{plural_atom}", bindings)
     else
-      do_t(locale, path, bindings)
+      do_t(norm_locale, path, bindings)
+    end
+  end
+
+  defp normalize_locale(locale) do
+    if String.match?(locale, ~r/-/) do
+      [lang, country] = String.split(locale, "-")
+      Enum.join([lang, String.upcase(country)], "-")
+    else
+      locale
     end
   end
 

--- a/test/fr-FR.yml
+++ b/test/fr-FR.yml
@@ -1,0 +1,4 @@
+---
+flash:
+  notice:
+    alert: "Ennui"

--- a/test/memorized_vocabulary_test.exs
+++ b/test/memorized_vocabulary_test.exs
@@ -3,11 +3,12 @@ defmodule MemorizedVocabularyTest do
 
   setup do
     Linguist.MemorizedVocabulary.locale("es", Path.join([__DIR__, "es.yml"]))
+    Linguist.MemorizedVocabulary.locale("fr-FR", Path.join([__DIR__, "fr-FR.yml"]))
     :ok
   end
 
   test "locales() returns locales" do
-    assert ["es"] == Linguist.MemorizedVocabulary.locales()
+    assert ["fr-FR", "es"] == Linguist.MemorizedVocabulary.locales()
   end
 
   test "t returns a translation" do
@@ -30,5 +31,9 @@ defmodule MemorizedVocabularyTest do
 
   test "t pluralizes" do
     assert {:ok, "2 manzanas"} == Linguist.MemorizedVocabulary.t("es", "apple", count: 2)
+  end
+
+  test "t will normalize a locale to format ll-LL" do
+    assert {:ok, "Ennui"} == Linguist.MemorizedVocabulary.t("fr-fr", "flash.notice.alert")
   end
 end


### PR DESCRIPTION
This pr adds a helper to normalize incoming locales. Transforming `es-es` to `es-ES`. 

@change/octopus 