### PR TITLE
Remove cldr compiler from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,6 @@ defmodule Linguist.Mixfile do
     [
       app: :linguist,
       version: @version,
-      compilers: Mix.compilers() ++ [:cldr],
       elixir: "~> 1.6",
       deps: deps(),
 


### PR DESCRIPTION
The cldr mix compiler was only required for `ex_cldr` version `1.x`. It is a no-op on `ex_cldr` version `2.x`.
