### PR TITLE
Fix atom locales

### DIFF
--- a/lib/linguist/compiler.ex
+++ b/lib/linguist/compiler.ex
@@ -42,7 +42,7 @@ defmodule Linguist.Compiler do
   @simple_interpol "%{"
 
   def compile(translations) do
-    langs = Keyword.keys(translations)
+    langs = Keyword.keys(translations) |> Enum.map(&to_string/1)
 
     translations =
       for {locale, source} <- translations do
@@ -51,6 +51,9 @@ defmodule Linguist.Compiler do
 
     quote do
       def t(locale, path, binding \\ [])
+      def t(locale, path, binding) when is_atom(locale) do
+        t(to_string(locale), path, binding)
+      end
       unquote(translations)
       def do_t(_locale, _path, _bindings), do: {:error, :no_translation}
 

--- a/lib/linguist/compiler.ex
+++ b/lib/linguist/compiler.ex
@@ -42,7 +42,12 @@ defmodule Linguist.Compiler do
   @simple_interpol "%{"
 
   def compile(translations) do
-    langs = Keyword.keys(translations) |> Enum.map(&to_string/1)
+    langs = translations |> Enum.reduce([], fn item, acc ->
+      case item do
+        {name, _paths} -> acc ++ [to_string(name)]
+        _ -> acc
+      end
+    end)
 
     translations =
       for {locale, source} <- translations do

--- a/lib/linguist/memorized_vocabulary.ex
+++ b/lib/linguist/memorized_vocabulary.ex
@@ -37,6 +37,10 @@ defmodule Linguist.MemorizedVocabulary do
   def t(locale, path, bindings \\ [])
   def t(nil, _, _), do: raise(LocaleError, nil)
 
+  def t(locale, path, binding) when is_atom(locale) do
+    t(to_string(locale), path, binding)
+  end
+
   def t(locale, path, bindings) do
     pluralization_key = Application.fetch_env!(:linguist, :pluralization_key)
     norm_locale = normalize_locale(locale)

--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -79,6 +79,8 @@ defmodule Linguist.Vocabulary do
             source
         end
 
+      name = name |> to_string()
+
       @locales {name, loaded_source}
     end
   end

--- a/test/vocabulary_test.exs
+++ b/test/vocabulary_test.exs
@@ -26,6 +26,11 @@ defmodule VocabularyTest do
     assert ["fr", "en", "es"] == I18n.locales()
   end
 
+  test "it handles both string and atom locales" do
+    assert I18n.t!("en", "foo") == I18n.t!(:en, "foo")
+    assert I18n.t("en", "foo") == I18n.t(:en, "foo")
+  end
+
   test "it handles translations at rool level" do
     assert I18n.t!("en", "foo") == "bar"
     assert I18n.t("en", "foo") == {:ok, "bar"}


### PR DESCRIPTION
Currently some locale arguments type mess is present in the module:
1. According to tests and documentation, locale should always be a string:
https://github.com/change/linguist/blob/dde41fa0b2ef9a15e9dbaca632893d36759fd365/test/vocabulary_test.exs#L6-L11
https://github.com/change/linguist/blob/dde41fa0b2ef9a15e9dbaca632893d36759fd365/test/memorized_vocabulary_test.exs#L5-L8

But if one is using Linguist.Vocabulary, it'll fail, like some existing tests:
```
== Compilation error in file test/escaping_test.exs ==
** (ArgumentError) expected a keyword list, but an entry in the list is not a two-element tuple with an atom as its first element, got: {"fr", [level: [basic: "%%{escaped}", mixed: "%{a} %%{a} %{a} %%{a}"]]}
    (elixir 1.11.0) lib/keyword.ex:475: Keyword.keys/1
    (linguist 0.3.1) lib/linguist/compiler.ex:45: Linguist.Compiler.compile/1
    (linguist 0.3.1) expanding macro: Linguist.Vocabulary.__before_compile__/1
    test/escaping_test.exs:4: EscapingTest.Esc (module)
    (elixir 1.11.0) lib/kernel/parallel_compiler.ex:416: Kernel.ParallelCompiler.require_file/2
    (elixir 1.11.0) lib/kernel/parallel_compiler.ex:316: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```

This is caused by https://github.com/change/linguist/blob/dde41fa0b2ef9a15e9dbaca632893d36759fd365/lib/linguist/compiler.ex#L45 - Keyword list is a list of `{atom, any}`, not `{binary, any}`.

2. If one passes locale as atom, the code will compile. But only string should be passed as locale argument for `t()` and `t!()` functions:
```
iex(2)> Arkenston.I18n.t("en", "default.authors.admin.first_name")
{:ok, "Super"}
iex(3)> Arkenston.I18n.t(:en, "default.authors.admin.first_name")
{:error, :no_translation}
```

That's not look like something consistent, does it?

3. If one is going to call `locales()` function, he will get list of atoms, not strings:
```
iex(4)> Arkenston.I18n.locales
[:ru, :en]
```


All of that prevents library from being used by newbies (they cannot make their project compile because documentation is wrong in some cases), and also it prevents from using locales as atoms (like Cldr does).

Here I've fixed all these issues:
1. Locale now can be either string or atom, it'll work anyway
2. `locales()` return list of binaries instead of atoms (because existing tests say that, but honestly I prefer atoms here).