### PR TITLE
Do not add es and fr locales into package

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,6 @@ config :linguist, pluralization_key: :count
 
 config :ex_cldr, json_library: Jason
 
-config :linguist, Linguist.Cldr, locales: ["fr", "en", "es"]
+if Mix.env() == :test do
+  config :linguist, Linguist.Cldr, locales: ["fr", "en", "es"]
+end


### PR DESCRIPTION
Currently if one installs linguist as a dependency, he will get `es` and `fr` locale configs downloaded from Cldr.
But they are important only for runing tests, so I've skipped them from production build.