### PR TITLE
Allow to pass custom Cldr module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```elixir
 defmodule I18n do
   use Linguist.Vocabulary
-  
+
   locale "en", [
     flash: [
       notice: [
@@ -22,7 +22,7 @@ defmodule I18n do
       ]
     ]
   ]
-  
+
   locale "fr", Path.join([__DIR__, "fr.exs"])
 
 end
@@ -48,9 +48,59 @@ iex> I18n.t!("en", "users.title")
 
 ## Configuration
 
+### Pluralization key
+
 The key to use for pluralization is configurable, and should likely be an atom:
 
 ```elixir
+# default
 config :linguist, pluralization_key: :count
 ```
-will cause the system to pluralize based on the `count` parameter passed to the `t` function.
+
+Will cause the system to pluralize based on the `count` parameter passed to the `t` function.
+
+But also you should add proper locale to Cldr backend.
+
+There are multiple ways to perform that:
+
+1. By default, linguist creates its own Cldr backend module `Linguist.Cldr`. It handles only `en` locale plurals but you can add more locales:
+
+```elixir
+config :linguist, Linguist.Cldr, locales: ["fr", "es"]
+```
+
+But this way is not recommended because it is not flexible.
+
+
+2. You can pass your own Cldr backend module within application config:
+
+```elixir
+config :linguist, cldr: MyApp.Cldr
+```
+
+3. If you've using `Linguist.Vocabulary`, you can pass own Cldr module name explicitly in your I18n module:
+
+```elixir
+defmodule I18n do
+  use Linguist.Vocabulary, cldr: MyApp.Cldr
+
+  ...
+end
+```
+
+or like that:
+
+```elixir
+defmodule I18n do
+  use Linguist.Vocabulary
+
+  @cldr MyApp.Cldr
+
+end
+```
+
+4. If you've using `Linguist.MemoizedVocabulary`, you can set up own Cldr module name:
+
+```elixir
+Linguist.MemorizedVocabulary.cldr(MyApp.Cldr)
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,8 @@
 use Mix.Config
 
-config :linguist, pluralization_key: :count
+config :linguist,
+  pluralization_key: :count,
+  cldr: Linguist.Cldr
 
 config :ex_cldr, json_library: Jason
 

--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -33,16 +33,21 @@ defmodule Linguist.Vocabulary do
   @doc """
   Compiles all the translations and inject the functions created in the current module.
   """
-  defmacro __using__(_options) do
+  defmacro __using__(options \\ []) do
+    cldr = Keyword.get(options, :cldr, Application.get_env(:linguist, :cldr))
     quote do
       Module.register_attribute(__MODULE__, :locales, accumulate: true, persist: false)
+
+      Module.register_attribute(__MODULE__, :cldr, accumulate: false, persist: false)
+      Module.put_attribute(__MODULE__, :cldr, unquote(cldr))
+
       import unquote(__MODULE__)
       @before_compile unquote(__MODULE__)
     end
   end
 
   defmacro __before_compile__(env) do
-    Compiler.compile(Module.get_attribute(env.module, :locales))
+    Compiler.compile(Module.get_attribute(env.module, :locales), Module.get_attribute(env.module, :cldr))
   end
 
   @doc """

--- a/test/memorized_vocabulary_test.exs
+++ b/test/memorized_vocabulary_test.exs
@@ -1,14 +1,22 @@
 defmodule MemorizedVocabularyTest do
   use ExUnit.Case
 
+  defmodule Ru.Cldr do
+    use Cldr,
+      providers: [],
+      default_locale: "en",
+      locales: ["ru", "en"]
+  end
+
   setup do
     Linguist.MemorizedVocabulary.locale("es", Path.join([__DIR__, "es.yml"]))
     Linguist.MemorizedVocabulary.locale("fr-FR", Path.join([__DIR__, "fr-FR.yml"]))
+    Linguist.MemorizedVocabulary.locale("ru", Path.join([__DIR__, "ru.yml"]))
     :ok
   end
 
   test "locales() returns locales" do
-    assert ["fr-FR", "es"] == Linguist.MemorizedVocabulary.locales()
+    assert ["ru", "fr-FR", "es"] == Linguist.MemorizedVocabulary.locales()
   end
 
   test "t returns a translation" do
@@ -23,6 +31,14 @@ defmodule MemorizedVocabularyTest do
                first: "Michael",
                last: "Westin"
              )
+  end
+
+  test "it handles unknown locales" do
+    assert Linguist.MemorizedVocabulary.t!("ru", "simple") == "простое"
+    assert Linguist.MemorizedVocabulary.t("ru", "simple") == {:ok, "простое"}
+
+    assert Linguist.MemorizedVocabulary.t!("ru", "interpolate", value: "значения") == "интерполяция значения"
+    assert Linguist.MemorizedVocabulary.t("ru", "interpolate", value: "значения") == {:ok, "интерполяция значения"}
   end
 
   test "t returns {:error, :no_translation} when translation is missing" do
@@ -51,5 +67,51 @@ defmodule MemorizedVocabularyTest do
     assert_raise Linguist.LocaleError, fn ->
       Linguist.MemorizedVocabulary.t(nil, "flash.notice.alert")
     end
+  end
+
+  test "t pluralized returns an error for unknown locale" do
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 1) |> elem(0) == :error
+  end
+
+  test "t! pluralized throws an error for unknown locale" do
+    assert_raise Cldr.UnknownLocaleError, fn ->
+      assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 1)
+    end
+  end
+
+  test "t! pluralizes unknown locale with custom Cldr backend" do
+    :ets.delete(:translations_registry, "memorized_vocabulary.cldr")
+
+    Linguist.MemorizedVocabulary.cldr(Ru.Cldr)
+
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 1) == "1 элемент"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 2) == "2 элемента"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 3) == "3 элемента"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 4) == "4 элемента"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 5) == "5 элементов"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 6) == "6 элементов"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 7) == "7 элементов"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 8) == "8 элементов"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 9) == "9 элементов"
+    assert Linguist.MemorizedVocabulary.t!("ru", "countable", count: 10) == "10 элементов"
+    :ets.delete(:translations_registry, "memorized_vocabulary.cldr")
+  end
+
+  test "t pluralizes unknown locale with custom Cldr backend" do
+    :ets.delete(:translations_registry, "memorized_vocabulary.cldr")
+
+    Linguist.MemorizedVocabulary.cldr(Ru.Cldr)
+
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 1) == {:ok, "1 элемент"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 2) == {:ok, "2 элемента"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 3) == {:ok, "3 элемента"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 4) == {:ok, "4 элемента"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 5) == {:ok, "5 элементов"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 6) == {:ok, "6 элементов"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 7) == {:ok, "7 элементов"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 8) == {:ok, "8 элементов"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 9) == {:ok, "9 элементов"}
+    assert Linguist.MemorizedVocabulary.t("ru", "countable", count: 10) == {:ok, "10 элементов"}
+    :ets.delete(:translations_registry, "memorized_vocabulary.cldr")
   end
 end

--- a/test/ru.yml
+++ b/test/ru.yml
@@ -1,0 +1,8 @@
+---
+simple: "простое"
+interpolate: "интерполяция %{value}"
+countable:
+  one: "%{count} элемент"
+  few: "%{count} элемента"
+  many: "%{count} элементов"
+  other: "%{count} элементов"


### PR DESCRIPTION
If one uses any language defined in Linguist.Cldr, it's fine, linguist will handle translations as usual.
If one uses any language which is unknown for Linguist.Cldr, but does not use pluralized keys, this is also fine - such operations as key search and string interpolation are also handled as usual.

But if one uses unknown language and a path which should be pluralized by Cldr, the error will be raised:
```
     ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:error, {Cldr.UnknownLocaleError, "The locale \"ru\" is not known."}} of type Tuple. This protocol is implemented for the following type(s): Decimal, Date, URI, Time, Integer, Version.Requirement, DateTime, NaiveDateTime, Float, Atom, Version, BitString, List
     code: I18n.t("ru", "countable", count: 1)
     stacktrace:
       (elixir 1.11.0) lib/string/chars.ex:3: String.Chars.impl_for!/1
       (elixir 1.11.0) lib/string/chars.ex:22: String.Chars.to_string/1
```

This could be more annoying after https://github.com/change/linguist/pull/32, because `fr` and `es` locales will be removed from package default config.

In this PR I've added feature of passing custom Cldr backend module into linguist app.
Possible ways are described in README.md, there are plenty of them.

Also `t()` function will return `{:error, _}` without throwing any exception and `t!()` function will throw an exception which was returned from Cldr module instead of Protocol.UndefinedError.

WIP status is set because this fix depends on https://github.com/change/linguist/pull/31, which should be merged first.