### PR TITLE
Use ubuntu-18.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -37,8 +37,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}
-          ${{ runner.os }}-mix
 
     - name: Restore _build cache
       uses: actions/cache@v2
@@ -48,16 +46,21 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-build-${{ matrix.otp }}
-          ${{ runner.os }}-build
 
-    - name: Install Dependencies
-      run: |
-        mix local.hex --force
-        mix local.rebar --force
-        mix deps.get --only test
+    - name: Install hex
+      run: mix local.hex --force
+
+    - name: Install rebar
+      run: mix local.rebar --force
+
+    - name: Install package dependencies
+      run: mix deps.get
+
+    - name: Remove compiled application files
+      run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
 
     - name: Run unit tests
-      run: |
-        mix clean
-        mix test
+      run: mix test


### PR DESCRIPTION
Ubuntu-latest recently was updated to 20.04, and Elixir installation fais on it.
I've rolled it back to 18.04 until Elixir installer will be fixed.