### PR TITLE
Skip duplicated Github actions run 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,27 @@ on:
       - master
 
 jobs:
+  check_duplicate_runs:
+    name: Check for duplicate runs
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: always
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/CHANGELOG.md", "**/LICENSE"]'
+          do_not_skip: '["pull_request"]'
+
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    needs: check_duplicate_runs
+    if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 
     strategy:
       matrix:
@@ -24,7 +42,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
@@ -32,26 +50,13 @@ jobs:
     - name: Restore deps cache
       uses: actions/cache@v2
       with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-
-    - name: Restore _build cache
-      uses: actions/cache@v2
-      with:
-        path: _build
-        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-
-    - name: Install hex
-      run: mix local.hex --force
-
-    - name: Install rebar
-      run: mix local.rebar --force
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
 
     - name: Install package dependencies
       run: mix deps.get
@@ -61,6 +66,8 @@ jobs:
 
     - name: Compile dependencies
       run: mix compile
+      env:
+        MIX_ENV: test
 
     - name: Run unit tests
       run: mix test


### PR DESCRIPTION
Hello.

There is an annoying fact about Github Actions - sometimes it runs actions twice. For example:
1. You just pushed a commit to a branch - testing workflow will run only once
2. Someone forked your repo and creates a pull request - same thing
3. You've created a new branch (feature, bugfix or release branch), pushed a commit here and also created a pull request to the main branch - two copies of workflow will be run

Running a workflow twice does not make any sense, it just takes twice the time without any useful side effect.

In this PR I've added a separated job of checking if another copy of workflow already started: https://github.com/fkirc/skip-duplicate-actions

This job allows to:
1. Skip the second copy of workflow in the case 3 (branch in original repo + PR to main branch). Cases 1 and 2 will work just the same as now
2. Skip workflow if someone changed only files which are not connected to package code, like README or CHANGELOG
3. Cancel already started workflow in the same PR or branch if someone pushed new commits to it.

Also I've found another quite annoying bug - step `actions/cache` does not update cache item if it was restored using a primary key.
For example, some dependencies like dialyzer or other ones store their files in `deps` or `_build` folders (which are cached in the workflow). But when these dependencies perform some updates of these folders, it does not lead to the updating of `mix.lock` file. File hasn't been changed -> hash is the same -> cache primary key is the same -> caching action will not update the existing cache.
This will cause the increase of workflow run time because the stored cache will not be used by some steps. Until `mix.lock` will be updated which will lead to updating the cache item.
Here I've appended a commit SHA to the cache primary key, so it will always be updated. But it will not affect cache reading.

What do you think about that?