### PR TITLE
Add :persistent_term support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,18 @@ on:
 jobs:
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
-        include:
-          - elixir: '1.11'
-            otp: '23'
-          - elixir: '1.10'
-            otp: '22'
+        elixir:
+        - "1.9"
+        - "1.10"
+        - "1.11"
+        otp:
+        - "21.0"
+        - "22.0.2"
+        - "23.0"
 
     steps:
     - name: Checkout
@@ -37,8 +40,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}
-          ${{ runner.os }}-mix
 
     - name: Restore _build cache
       uses: actions/cache@v2
@@ -48,8 +49,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-build-${{ matrix.otp }}
-          ${{ runner.os }}-build
 
     - name: Install Dependencies
       run: |
@@ -61,3 +60,9 @@ jobs:
       run: |
         mix clean
         mix test
+
+    - name: Run unit tests with persistent_term backend
+      run: mix test
+      if: matrix.otp != '21.0'
+      env:
+        SCHEMA_PROVIDER: persistent_term

--- a/README.md
+++ b/README.md
@@ -48,9 +48,22 @@ iex> I18n.t!("en", "users.title")
 
 ## Configuration
 
+### Pluralization key
+
 The key to use for pluralization is configurable, and should likely be an atom:
 
 ```elixir
 config :linguist, pluralization_key: :count
 ```
+
 will cause the system to pluralize based on the `count` parameter passed to the `t` function.
+
+### `:persistent_term` support
+
+Also you can use [`:persistent_term`](https://erlang.org/doc/man/persistent_term.html) backend instead of `:ets` in `Linguist.MemoizedVocabulary` by setting up:
+
+```elixir
+config :linguist, vocabulary_backend: :persistent_term
+```
+
+**This is only available on OTP >= 21.2**

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
 use Mix.Config
 
-config :linguist, pluralization_key: :count
-
 config :ex_cldr, json_library: Jason
 
 if Mix.env() == :test do
   config :linguist, Linguist.Cldr, locales: ["fr", "en", "es"]
+
+  config :linguist, vocabulary_backend: (System.get_env("SCHEMA_PROVIDER") || "ets") |> String.to_existing_atom()
 end

--- a/lib/linguist/compiler.ex
+++ b/lib/linguist/compiler.ex
@@ -62,12 +62,10 @@ defmodule Linguist.Compiler do
       end
 
       def t(locale, path, bindings) do
-        pluralization_key = Application.fetch_env!(:linguist, :pluralization_key)
-
-        if Keyword.has_key?(bindings, pluralization_key) do
+        if Keyword.has_key?(bindings, @pluralization_key) do
           plural_atom =
             bindings
-            |> Keyword.get(pluralization_key)
+            |> Keyword.get(@pluralization_key)
             |> Cardinal.plural_rule(locale)
 
           new_path = "#{path}.#{plural_atom}"
@@ -76,7 +74,7 @@ defmodule Linguist.Compiler do
           do_t(locale, path, bindings)
         end
       end
-      
+
       unquote(translations)
 
       def do_t(_locale, _path, _bindings), do: {:error, :no_translation}

--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -36,6 +36,7 @@ defmodule Linguist.Vocabulary do
   defmacro __using__(_options) do
     quote do
       Module.register_attribute(__MODULE__, :locales, accumulate: true, persist: false)
+      @pluralization_key Application.get_env(:linguist, :pluralization_key, :count)
       import unquote(__MODULE__)
       @before_compile unquote(__MODULE__)
     end


### PR DESCRIPTION
Currently `MemoizedVocabulary` uses `:ets` for storing the translations.
But OTP 21.2 provides a new `:persistent_term` module. It has the same get/put methods like :ets, but significantly improved performance for storing mostly read-only data:
https://erlang.org/doc/man/persistent_term.html

It looks like translations are never changed since booting the application, so this module just perfectly suits for storing them.

Here I've added new config key `vocabulary_backend` with 2 possible options: `:ets` (default) and `:persistent_term`.
If someone will try to use :persitent_term on too old OTP version, an exception will be raised during compilation step.