### PR TITLE
Allow to pass locales as atoms to MemorizedVocabulary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -37,8 +37,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}
-          ${{ runner.os }}-mix
 
     - name: Restore _build cache
       uses: actions/cache@v2
@@ -48,8 +46,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-build-${{ matrix.otp }}
-          ${{ runner.os }}-build
 
     - name: Install Dependencies
       run: |

--- a/lib/linguist/memorized_vocabulary.ex
+++ b/lib/linguist/memorized_vocabulary.ex
@@ -103,10 +103,11 @@ defmodule Linguist.MemorizedVocabulary do
 
   def add_locale(name) do
     current_locales = locales() || []
+    new_locales = [name | current_locales] |> Enum.uniq()
 
     :ets.insert(
       :translations_registry,
-      {"memorized_vocabulary.locales", [name | current_locales]}
+      {"memorized_vocabulary.locales", new_locales}
     )
   end
 
@@ -128,6 +129,7 @@ defmodule Linguist.MemorizedVocabulary do
   locale "es", Path.join([__DIR__, "es.yml"])
   """
   def locale(name, source) do
+    name = normalize_locale(name)
     loaded_source = Linguist.MemorizedVocabulary._load_yaml_file(source)
     update_translations(name, loaded_source)
     add_locale(name)
@@ -206,6 +208,8 @@ defmodule Linguist.MemorizedVocabulary do
   # splits the string on the `-` downcases the first part and upcases the second part.
   # With a locale that contains no `-` the string is downcased, and if the locale contains more
   # than one `-`, a LocaleError is raised.
+  def normalize_locale(locale) when is_atom(locale), do: normalize_locale(to_string(locale))
+
   def normalize_locale(locale) do
     if String.match?(locale, ~r/-/) do
       case String.split(locale, "-") do

--- a/test/memorized_vocabulary_test.exs
+++ b/test/memorized_vocabulary_test.exs
@@ -2,7 +2,7 @@ defmodule MemorizedVocabularyTest do
   use ExUnit.Case
 
   setup do
-    Linguist.MemorizedVocabulary.locale("es", Path.join([__DIR__, "es.yml"]))
+    Linguist.MemorizedVocabulary.locale(:es, Path.join([__DIR__, "es.yml"]))
     Linguist.MemorizedVocabulary.locale("fr-FR", Path.join([__DIR__, "fr-FR.yml"]))
     :ok
   end
@@ -13,6 +13,7 @@ defmodule MemorizedVocabularyTest do
 
   test "t returns a translation" do
     assert {:ok, "bar"} == Linguist.MemorizedVocabulary.t("es", "foo")
+    assert {:ok, "bar"} == Linguist.MemorizedVocabulary.t(:es, "foo")
   end
 
   test "t interpolates values" do
@@ -23,32 +24,52 @@ defmodule MemorizedVocabularyTest do
                first: "Michael",
                last: "Westin"
              )
+    assert {:ok, "hola Michael Westin"} ==
+            Linguist.MemorizedVocabulary.t(
+              :es,
+              "flash.notice.hello",
+              first: "Michael",
+              last: "Westin"
+            )
   end
 
   test "t returns {:error, :no_translation} when translation is missing" do
     assert Linguist.MemorizedVocabulary.t("es", "flash.not_exists") == {:error, :no_translation}
+    assert Linguist.MemorizedVocabulary.t(:es, "flash.not_exists") == {:error, :no_translation}
   end
 
   test "t! raises NoTranslationError when translation is missing" do
     assert_raise Linguist.NoTranslationError, fn ->
       Linguist.MemorizedVocabulary.t!("es", "flash.not_exists")
     end
+    assert_raise Linguist.NoTranslationError, fn ->
+      Linguist.MemorizedVocabulary.t!(:es, "flash.not_exists")
+    end
   end
 
   test "t pluralizes" do
     assert {:ok, "2 manzanas"} == Linguist.MemorizedVocabulary.t("es", "apple", count: 2)
+    assert {:ok, "2 manzanas"} == Linguist.MemorizedVocabulary.t(:es, "apple", count: 2)
   end
 
   test "t will normalize a locale to format ll-LL" do
     assert {:ok, "Ennui"} == Linguist.MemorizedVocabulary.t("FR-fr", "flash.notice.alert")
+    assert {:ok, "Ennui"} == Linguist.MemorizedVocabulary.t(:"FR-fr", "flash.notice.alert")
   end
 
   test "t will raise a LocaleError if a malformed locale is passed in" do
     assert_raise Linguist.LocaleError, fn ->
+      Linguist.MemorizedVocabulary.locale("es-es-es", Path.join([__DIR__, "es.yml"]))
       Linguist.MemorizedVocabulary.t("es-es-es", "flash.notice.alert")
     end
 
     assert_raise Linguist.LocaleError, fn ->
+      Linguist.MemorizedVocabulary.locale(:"es-es-es", Path.join([__DIR__, "es.yml"]))
+      Linguist.MemorizedVocabulary.t(:"es-es-es", "flash.notice.alert")
+    end
+
+    assert_raise Linguist.LocaleError, fn ->
+      Linguist.MemorizedVocabulary.locale(nil, Path.join([__DIR__, "es.yml"]))
       Linguist.MemorizedVocabulary.t(nil, "flash.notice.alert")
     end
   end


### PR DESCRIPTION
Hello.

I've already fixed passing locales as atoms into t! and t functions: #30
But MemorizedVocabulary module does not check locale before saving it to :ets. So you can easily add call `locale(:en, ...)`, but then you cannot call `t(:en, "path")` because locale here is checked with `normalize_locale` function which accepts only strings.

What I've changed::
1. Added locale name normalization step to `locale/2` function
2. Allowed to pass atom locales into `normalize_locale/1` function
3. Added few tests for this case