### PR TITLE
chore(deps): add Dependabot cooldown (3d) to version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,12 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary

Adds a `cooldown` block to every update entry in `.github/dependabot.yml` so Dependabot only opens version-update PRs for package versions that have been published for at least **3 days**.

Standard (non-security-sensitive) repos use a **3-day** cooldown.

## Why

Newly published packages are sometimes quickly yanked or receive an immediate patch. A short cooldown reduces churn from those ephemeral releases.

## Security updates are not affected

Dependabot security updates are triggered by GitHub's vulnerability advisory database and bypass `cooldown` entirely — they will still open immediately when a CVE is detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)